### PR TITLE
Display full address and match input styling

### DIFF
--- a/src/components/AddressSelector.js
+++ b/src/components/AddressSelector.js
@@ -13,7 +13,7 @@ function AddressSelector({ addresses, selected, onSelect }) {
       <select
         value={selected}
         onChange={(e) => onSelect(e.target.value)}
-        className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-primary"
+        className="w-full px-4 py-3 rounded-lg text-white bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 focus:outline-none"
       >
         <option value="">Please choose...</option>
         {addresses.map((addr, idx) => (

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -32,7 +32,7 @@ function HomePage() {
               value={postcode}
               onChange={(e) => setPostcode(e.target.value)}
               placeholder="e.g. SK9 5AE"
-              className="flex-grow px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary"
+              className="flex-grow px-4 py-3 rounded-lg text-white placeholder-gray-200 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 focus:outline-none"
             />
             <button
               onClick={handleProceed}

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -40,7 +40,7 @@ function LoginPage({ onLogin }) {
             onChange={(e) => setEmail(e.target.value)}
             placeholder="Email"
             required
-            className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary"
+            className="w-full px-4 py-3 rounded-lg text-white placeholder-gray-200 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 focus:outline-none"
           />
           <input
             type="password"
@@ -48,7 +48,7 @@ function LoginPage({ onLogin }) {
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
             required
-            className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary"
+            className="w-full px-4 py-3 rounded-lg text-white placeholder-gray-200 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 focus:outline-none"
           />
           <button
             type="submit"

--- a/src/pages/PropertyPage.js
+++ b/src/pages/PropertyPage.js
@@ -31,13 +31,12 @@ const PropertyPage = () => {
         if (data && data.addresses) {
           // Map the API response into user friendly strings
           const formatted = data.addresses.map((item) => {
-            // The API returns an object with lines, town, county and postcode
+            // The API returns properties like line_1, line_2, locality, town_or_city, county and postcode
+            // Collect all available parts so the full address is displayed rather than just town and county
             const lines = [];
-            if (item.address_line_1) lines.push(item.address_line_1);
-            if (item.address_line_2) lines.push(item.address_line_2);
-            if (item.town_or_city) lines.push(item.town_or_city);
-            if (item.county) lines.push(item.county);
-            if (item.postcode) lines.push(item.postcode);
+            ['line_1', 'line_2', 'line_3', 'line_4', 'locality', 'town_or_city', 'county', 'postcode'].forEach((key) => {
+              if (item[key]) lines.push(item[key]);
+            });
             return lines.join(', ');
           });
           setAddresses(formatted);


### PR DESCRIPTION
## Summary
- include all address lines from getAddress.io so full address appears in selector
- restyle postcode, login, and address selector inputs with site gradient scheme

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b105a6a3188330ae6a15c8612aa4c6