### PR TITLE
Improve address selector UI and data fetch flow

### DIFF
--- a/src/components/AddressSelector.js
+++ b/src/components/AddressSelector.js
@@ -10,16 +10,18 @@ function AddressSelector({ addresses, selected, onSelect }) {
   return (
     <div className="space-y-2">
       <label className="block text-gray-600 font-medium">Select address</label>
-      <select
-        value={selected}
-        onChange={(e) => onSelect(e.target.value)}
-        className="w-full px-4 py-3 rounded-lg text-white bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 focus:outline-none"
-      >
-        <option value="">Please choose...</option>
-        {addresses.map((addr, idx) => (
-          <option key={idx} value={addr}>{addr}</option>
-        ))}
-      </select>
+      <div className="p-[2px] rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 shadow-[0_0_8px_rgba(99,102,241,0.5)]">
+        <select
+          value={selected}
+          onChange={(e) => onSelect(e.target.value)}
+          className="w-full px-4 py-3 rounded-md bg-white text-gray-800 focus:outline-none"
+        >
+          <option value="">Please choose...</option>
+          {addresses.map((addr, idx) => (
+            <option key={idx} value={addr}>{addr}</option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 }

--- a/src/pages/PropertyPage.js
+++ b/src/pages/PropertyPage.js
@@ -397,7 +397,7 @@ const PropertyPage = () => {
           Postcode: <strong>{postcode}</strong>
         </p>
         {/* Address selector. Display this until the user picks an address. */}
-        {addresses.length > 0 && !selectedAddress && (
+        {addresses.length > 0 && (
           <div className="mb-6">
             <AddressSelector
               addresses={addresses}
@@ -420,6 +420,11 @@ const PropertyPage = () => {
             <div className="flex-grow">
               {loading && (
                 <p className="text-gray-600 mb-4">Fetching data…</p>
+              )}
+              {!loading && Object.keys(results).length === 0 && (
+                <p className="text-gray-600 mb-4">
+                  No data loaded yet. Select an address and click "Fetch property data".
+                </p>
               )}
               {!loading && Object.keys(results).length > 0 && (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- Restyle address dropdown with white background and blue to purple gradient border for better readability
- Always render the address selector and fetch button so property data loads after selection
- Show a helpful message when no property data has been loaded

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b10c5aafe88330a12ae7c17bc5d0f4